### PR TITLE
ADD: add main dashboard page and create interview dialog

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1429,6 +1429,14 @@
         }
       }
     },
+    "@material-ui/icons": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.9.1.tgz",
+      "integrity": "sha512-GBitL3oBWO0hzBhvA9KxqcowRUsA0qzwKkURyC8nppnC3fw54KPKZ+d4V1Eeg/UnDRSzDaI9nGCdel/eh9AQMg==",
+      "requires": {
+        "@babel/runtime": "^7.4.4"
+      }
+    },
     "@material-ui/lab": {
       "version": "4.0.0-alpha.56",
       "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.56.tgz",
@@ -2020,6 +2028,11 @@
         "mime-types": "~2.1.24",
         "negotiator": "0.6.2"
       }
+    },
+    "ace-builds": {
+      "version": "1.4.12",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.4.12.tgz",
+      "integrity": "sha512-G+chJctFPiiLGvs3+/Mly3apXTcfgE45dT5yp12BcWZ1kUs+gm0qd3/fv4gsz6fVag4mM0moHVpjHDIgph6Psg=="
     },
     "acorn": {
       "version": "7.4.0",
@@ -4402,6 +4415,11 @@
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
+    },
+    "diff-match-patch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw=="
     },
     "diff-sequences": {
       "version": "24.9.0",
@@ -7996,6 +8014,16 @@
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -10436,6 +10464,18 @@
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
         "scheduler": "^0.13.6"
+      }
+    },
+    "react-ace": {
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/react-ace/-/react-ace-9.1.3.tgz",
+      "integrity": "sha512-1TZBs/9hFGgPuzu6DUiBogyhRA5Z1Po2wzPfZslbrTFGQtbNe+JXHuPoJNlUu/uerElzOLLsuJEDTO9FfLnZJA==",
+      "requires": {
+        "ace-builds": "^1.4.6",
+        "diff-match-patch": "^1.0.4",
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "prop-types": "^15.7.2"
       }
     },
     "react-app-polyfill": {

--- a/client/package.json
+++ b/client/package.json
@@ -4,8 +4,11 @@
   "private": true,
   "dependencies": {
     "@material-ui/core": "^4.11.0",
+    "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.56",
+    "ace-builds": "^1.4.12",
     "react": "^16.8.6",
+    "react-ace": "^9.1.3",
     "react-dom": "^16.8.6",
     "react-hook-form": "^6.4.1",
     "react-router-dom": "^5.2.0",

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -13,7 +13,7 @@ import { UserContext } from "./utils/context/userContext";
 
 function App() {
   const [userData, setUserData] = useState({
-    isSignedIn: undefined,
+    isSignedIn: true,
     user: undefined,
   });
 

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -16,7 +16,7 @@ function App() {
     isSignedIn: true,
     user: undefined,
   });
-
+  const [isLoaded, setIsLoaded] = useState(false);
   useEffect(() => {
     const checkLoggedIn = async () => {
       let status;
@@ -38,6 +38,7 @@ function App() {
               user: undefined,
             });
           }
+          setIsLoaded(true);
         })
         .catch((err) => {
           console.log(err.message);
@@ -49,34 +50,36 @@ function App() {
   return (
     <MuiThemeProvider theme={theme}>
       <CssBaseline />
-      <BrowserRouter>
-        <UserContext.Provider value={{ userData, setUserData }}>
-          <RouteContainer
-            path="/"
-            component={Register}
-            layoutProps={{
-              titleHeader: "Already have an account?",
-              buttonTitleHeader: "Sign In",
-              buttonUrlHeader: "/login",
-            }}
-            exact
-          />
-          <RouteContainer
-            path="/login"
-            component={Login}
-            layoutProps={{
-              titleHeader: "Don't have an account?",
-              buttonTitleHeader: "Sign Up",
-              buttonUrlHeader: "/",
-            }}
-          />
-          <RouteContainer
-            path="/dashboard"
-            component={Dashboard}
-            isPrivateRoute
-          />
-        </UserContext.Provider>
-      </BrowserRouter>
+      {isLoaded && (
+        <BrowserRouter>
+          <UserContext.Provider value={{ userData, setUserData }}>
+            <RouteContainer
+              path="/"
+              component={Register}
+              layoutProps={{
+                titleHeader: "Already have an account?",
+                buttonTitleHeader: "Sign In",
+                buttonUrlHeader: "/login",
+              }}
+              exact
+            />
+            <RouteContainer
+              path="/login"
+              component={Login}
+              layoutProps={{
+                titleHeader: "Don't have an account?",
+                buttonTitleHeader: "Sign Up",
+                buttonUrlHeader: "/",
+              }}
+            />
+            <RouteContainer
+              path="/dashboard"
+              component={Dashboard}
+              isPrivateRoute
+            />
+          </UserContext.Provider>
+        </BrowserRouter>
+      )}
     </MuiThemeProvider>
   );
 }

--- a/client/src/components/AccountHeader.js
+++ b/client/src/components/AccountHeader.js
@@ -56,8 +56,8 @@ const AccountHeader = ({ title, buttonTitle, buttonUrl }) => {
 };
 
 AccountHeader.propTypes = {
-  title: PropTypes.string.isRequired,
-  buttonTitle: PropTypes.string.isRequired,
+  title: PropTypes.string,
+  buttonTitle: PropTypes.string,
 };
 
 export default AccountHeader;

--- a/client/src/components/AppHeader.js
+++ b/client/src/components/AppHeader.js
@@ -45,12 +45,12 @@ const useStyles = makeStyles((theme) => ({
 const AppHeader = () => {
   const classes = useStyles();
   const preventDefault = (event) => event.preventDefault();
-  const { userData, setUserData } = useContext(UserContext);
+  const { userData } = useContext(UserContext);
   return (
     <AppBar position="absolute" className={classes.appBar}>
       <Toolbar className={classes.toolbar}>
         <div className={classes.logoContainer}>
-          <img className={classes.logo} src={Logo} />
+          <img className={classes.logo} src={Logo} alt="logo" />
         </div>
         <Link
           href="#"
@@ -77,7 +77,14 @@ const AppHeader = () => {
           Faq
         </Link>
         <Avatar
-          alt="Remy Sharp"
+          alt={
+            userData.user
+              ? userData.user.firstName +
+                " " +
+                userData.user.lastName +
+                " image"
+              : null
+          }
           src={AvatarImg}
           className={classes.avatarImg}
         />

--- a/client/src/components/CreateInterview.js
+++ b/client/src/components/CreateInterview.js
@@ -1,0 +1,170 @@
+import React, { useState, useEffect } from "react";
+import PropTypes from "prop-types";
+import { makeStyles } from "@material-ui/core/styles";
+import Dialog from "@material-ui/core/Dialog";
+import FormControl from "@material-ui/core/FormControl";
+import Select from "@material-ui/core/Select";
+import IconButton from "@material-ui/core/IconButton";
+import CloseIcon from "@material-ui/icons/Close";
+import { Typography } from "@material-ui/core";
+import { useForm } from "react-hook-form";
+import TextField from "@material-ui/core/TextField";
+import Button from "@material-ui/core/Button";
+import InterviewApi from "../utils/api/interview";
+
+const useStyles = makeStyles((theme) => ({
+  title: {
+    color: "#516BF6",
+    textAlign: "center",
+    fontWeight: 600,
+  },
+  dialogContainer: {
+    padding: "50px 80px",
+  },
+  formControl: {
+    marginTop: theme.spacing(3),
+    minWidth: 200,
+  },
+  createButton: {
+    borderRadius: "5em",
+    padding: "10px 30px",
+  },
+  createButtonContainer: {
+    textAlign: "center",
+    marginTop: theme.spacing(3),
+  },
+  label: {
+    fontWeight: 400,
+    fontSize: 14,
+    marginTop: 20,
+  },
+  closeButton: {
+    position: "absolute",
+    right: theme.spacing(1),
+    top: theme.spacing(1),
+    color: theme.palette.grey[500],
+  },
+  input: {
+    margin: "5px 0px 35px 0px ",
+    width: 300,
+  },
+}));
+
+const CreateInterview = (props) => {
+  const classes = useStyles();
+  const { onClose, onSend, open } = props;
+  const [difficulty, setDifficulty] = useState();
+  const [difficultyList, setDifficultyList] = useState([]);
+  const [title, setTitle] = useState();
+  const { register, handleSubmit, errors } = useForm();
+
+  const handleClose = () => {
+    onClose();
+  };
+
+  const handleChangeDifficulty = (event) => {
+    setDifficulty(event.target.value);
+  };
+
+  const handleChange = (event) => {
+    setTitle(event.target.value);
+  };
+
+  const onSubmit = () => {
+    onSend({
+      title: title,
+      level: difficulty,
+    });
+  };
+
+  const getDifficultyList = async () => {
+    let status;
+    InterviewApi.getListDifficultyLevels()
+      .then((res) => {
+        status = res.status;
+        if (status < 500) return res.json();
+        else throw Error("Server error");
+      })
+      .then((res) => {
+        if (status === 200) {
+          setDifficultyList(res);
+          setDifficulty(res[0]._id);
+        } else {
+        }
+      })
+      .catch((err) => {
+        console.log(err.message);
+      });
+  };
+
+  useEffect(() => {
+    getDifficultyList();
+  }, []);
+
+  return (
+    <Dialog onClose={handleClose} open={open}>
+      <IconButton
+        aria-label="close"
+        className={classes.closeButton}
+        onClick={handleClose}
+      >
+        <CloseIcon fontSize="small" />
+      </IconButton>
+      <div className={classes.dialogContainer}>
+        <Typography component="h5" variant="h5" className={classes.title}>
+          Create
+        </Typography>
+        <form onSubmit={handleSubmit(onSubmit)} noValidate>
+          <FormControl variant="outlined" className={classes.formControl}>
+            <Typography component="h6" variant="h6" className={classes.label}>
+              Difficulty level
+            </Typography>
+            <Select native value={difficulty} onChange={handleChangeDifficulty}>
+              {difficultyList.map((value, index) => {
+                return (
+                  <option value={value._id} key={index}>
+                    {value.name}
+                  </option>
+                );
+              })}
+            </Select>
+            <Typography component="h6" variant="h6" className={classes.label}>
+              Interview title
+            </Typography>
+            <TextField
+              variant="outlined"
+              className={classes.input}
+              required
+              fullWidth
+              id="title"
+              placeholder="Interview title"
+              name="title"
+              onChange={(event) => handleChange(event)}
+              inputRef={register({ required: "Interview Title is required" })}
+              helperText={errors.title ? errors.title.message : null}
+              autoFocus
+            />
+          </FormControl>
+          <div className={classes.createButtonContainer}>
+            <Button
+              type="submit"
+              variant="contained"
+              color="primary"
+              className={classes.createButton}
+            >
+              Create
+            </Button>
+          </div>
+        </form>
+      </div>
+    </Dialog>
+  );
+};
+
+CreateInterview.propTypes = {
+  onClose: PropTypes.func.isRequired,
+  onSend: PropTypes.func.isRequired,
+  open: PropTypes.bool.isRequired,
+};
+
+export default CreateInterview;

--- a/client/src/components/PastInterviews.js
+++ b/client/src/components/PastInterviews.js
@@ -1,0 +1,143 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Typography } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
+import Button from "@material-ui/core/Button";
+import Rating from "@material-ui/lab/Rating";
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    width: "100%",
+  },
+  item: {
+    width: "100%",
+    height: "auto",
+    display: "flex",
+    backgroundColor: "#FFFFFF",
+    padding: "30px 20px 30px 20px",
+    borderBottom: "1px solid #D4D9E2",
+  },
+  lastItem: {
+    width: "100%",
+    height: "auto",
+    display: "flex",
+    backgroundColor: "#FFFFFF",
+    padding: "30px 20px 30px 20px",
+    borderBottomLeftRadius: 6,
+    borderBottomRightRadius: 6,
+  },
+  itemContent: {
+    width: "33%",
+  },
+  headerTitle: {
+    width: "33%",
+    color: "#FFFFFF",
+    fontSize: 16,
+    fontWeight: 600,
+    lineHeight: 22,
+  },
+  button: {
+    padding: "10px 30px",
+    borderRadius: "5em",
+    fontWeight: "600",
+    fontSize: 13,
+    textTransform: "uppercase",
+    color: "#5E6676",
+    marginRight: 10,
+  },
+  headerCard: {
+    backgroundColor: "#516BF6",
+    width: "100%",
+    height: "50px",
+    borderTopLeftRadius: 6,
+    borderTopRightRadius: 6,
+    padding: "15px 20px",
+    display: "flex",
+  },
+}));
+
+const PastInterviews = ({ pastInterviewsList }) => {
+  const classes = useStyles();
+
+  return (
+    <div className={classes.root}>
+      <div className={classes.headerCard}>
+        <div className={classes.headerTitle}>
+          <Typography component="h6" variant="h6" color="inherit">
+            Held on
+          </Typography>
+        </div>
+        <div className={classes.headerTitle}>
+          <Typography component="h6" variant="h6" color="inherit">
+            Codding
+          </Typography>
+        </div>
+        <div className={classes.headerTitle}>
+          <Typography component="h6" variant="h6" color="inherit">
+            Communication
+          </Typography>
+        </div>
+        <div className={classes.headerTitle}>
+          <Typography component="h6" variant="h6" color="inherit">
+            Questions
+          </Typography>
+        </div>
+        <div className={classes.headerTitle}>
+          <Typography component="h6" variant="h6" color="inherit">
+            Detailed feedback
+          </Typography>
+        </div>
+      </div>
+      {pastInterviewsList.map((value, index) => {
+        return (
+          <div
+            className={
+              index === pastInterviewsList.length - 1
+                ? classes.lastItem
+                : classes.item
+            }
+            key={index}
+          >
+            <div className={classes.itemContent}>
+              <Typography component="h6" variant="h6" color="inherit">
+                {value.date}
+              </Typography>
+            </div>
+            <div className={classes.itemContent}>
+              <Rating
+                name="half-rating-read"
+                defaultValue={value.codding}
+                precision={0.5}
+                readOnly
+              />
+            </div>
+            <div className={classes.itemContent}>
+              <Rating
+                name="half-rating-read"
+                defaultValue={value.communication}
+                precision={0.5}
+                readOnly
+              />
+            </div>
+            <div className={classes.itemContent}>
+              <Button variant="outlined" className={classes.button}>
+                View
+              </Button>
+            </div>
+            <div className={classes.itemContent}>
+              <Button variant="outlined" className={classes.button}>
+                View
+              </Button>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+PastInterviews.propTypes = {
+  pastInterviewsList: PropTypes.array.isRequired,
+};
+
+export default PastInterviews;

--- a/client/src/components/UpcomingInterviews.js
+++ b/client/src/components/UpcomingInterviews.js
@@ -1,0 +1,139 @@
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+import { Typography } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
+import Button from "@material-ui/core/Button";
+import Link from "@material-ui/core/Link";
+import WaitingRoom from "../components/WaitingRoom";
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    width: "100%",
+  },
+  item: {
+    width: "100%",
+    height: "auto",
+    display: "flex",
+    backgroundColor: "#FFFFFF",
+    padding: "30px 20px 30px 20px",
+    borderBottom: "1px solid #D4D9E2",
+  },
+  lastItem: {
+    width: "100%",
+    height: "auto",
+    display: "flex",
+    backgroundColor: "#FFFFFF",
+    padding: "30px 20px 30px 20px",
+    borderBottomLeftRadius: 6,
+    borderBottomRightRadius: 6,
+  },
+  itemContent: {
+    width: "33%",
+  },
+  headerTitle: {
+    width: "33%",
+    color: "#FFFFFF",
+    fontSize: 16,
+    fontWeight: 600,
+    lineHeight: 22,
+  },
+  button: {
+    padding: "10px 30px",
+    borderRadius: "5em",
+    fontWeight: "600",
+    fontSize: 13,
+    textTransform: "uppercase",
+    color: "#5E6676",
+    marginRight: 10,
+  },
+  headerCard: {
+    backgroundColor: "#516BF6",
+    width: "100%",
+    height: "50px",
+    borderTopLeftRadius: 6,
+    borderTopRightRadius: 6,
+    padding: "15px 20px",
+    display: "flex",
+  },
+}));
+
+const UpcomingInterviews = ({ upcomingInterviewsList }) => {
+  const classes = useStyles();
+
+  const [openWaitingRoom, setOpenWaitingRoom] = useState(false);
+
+  const handleClickOpenWaitingRoom = () => {
+    setOpenWaitingRoom(true);
+  };
+
+  const handleCloseWaitingRoom = (value) => {
+    setOpenWaitingRoom(false);
+  };
+
+  return (
+    <div className={classes.root}>
+      <div className={classes.headerCard}>
+        <div className={classes.headerTitle}>
+          <Typography component="h6" variant="h6" color="inherit">
+            Interview title
+          </Typography>
+        </div>
+        <div className={classes.headerTitle}>
+          <Typography component="h6" variant="h6" color="inherit">
+            Difficulty level
+          </Typography>
+        </div>
+        <div className={classes.headerTitle}>
+          <Typography component="h6" variant="h6" color="inherit">
+            Action
+          </Typography>
+        </div>
+      </div>
+      {upcomingInterviewsList.map((value, index) => {
+        return (
+          <div
+            className={
+              index === upcomingInterviewsList.length - 1
+                ? classes.lastItem
+                : classes.item
+            }
+            key={index}
+          >
+            <div className={classes.itemContent}>
+              <Typography component="h6" variant="h6" color="inherit">
+                <Link>{value.title}</Link>
+              </Typography>
+            </div>
+            <div className={classes.itemContent}>
+              <Typography component="h6" variant="h6" color="inherit">
+                {value.level.name}
+              </Typography>
+            </div>
+            <div className={classes.itemContent}>
+              <Button variant="outlined" className={classes.button}>
+                Cancel
+              </Button>
+              <Button
+                variant="outlined"
+                className={classes.button}
+                onClick={handleClickOpenWaitingRoom}
+              >
+                Join
+              </Button>
+              <WaitingRoom
+                open={openWaitingRoom}
+                onClose={handleCloseWaitingRoom}
+              ></WaitingRoom>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+UpcomingInterviews.propTypes = {
+  upcomingInterviewsList: PropTypes.array.isRequired,
+};
+
+export default UpcomingInterviews;

--- a/client/src/layouts/AppLayout.js
+++ b/client/src/layouts/AppLayout.js
@@ -1,7 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { makeStyles } from "@material-ui/core/styles";
-import { Container } from "@material-ui/core";
 import AppHeader from "../components/AppHeader";
 
 const useStyles = makeStyles({
@@ -14,7 +13,7 @@ const AppLayout = ({ children }) => {
   return (
     <div className={classes.root}>
       <AppHeader></AppHeader>
-      <Container>{children}</Container>
+      <div>{children}</div>
     </div>
   );
 };

--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -1,91 +1,127 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import Typography from "@material-ui/core/Typography";
 import { makeStyles } from "@material-ui/core/styles";
-import Link from "@material-ui/core/Link";
 import Grid from "@material-ui/core/Grid";
-import Button from "@material-ui/core/Button";
 import Container from "@material-ui/core/Container";
-import { userContext } from "../utils/context/userContext";
+import Button from "@material-ui/core/Button";
+import UpcomingInterviews from "../components/UpcomingInterviews";
+import PastInterviews from "../components/PastInterviews";
+import CreateInterview from "../components/CreateInterview";
+import InterviewApi from "../utils/api/interview";
 
 const useStyles = makeStyles((theme) => ({
-  paper: {
-    display: "flex",
-  },
   titleCard: {
     color: "#516BF6",
     marginBottom: 40,
-  },
-  headerCard: {
-    backgroundColor: "#516BF6",
-    width: "100%",
-    height: "50px",
-    borderTopLeftRadius: 6,
-    borderTopRightRadius: 6,
-    padding: "15px 20px",
-    display: "flex",
+    textAlign: "center",
   },
   content: {},
   container: {
-    paddingTop: theme.spacing(20),
+    paddingTop: theme.spacing(10),
     paddingBottom: theme.spacing(10),
   },
   appBarSpacer: theme.mixins.toolbar,
-  item: {
+  pastInterviewsContainer: {
+    marginTop: theme.spacing(10),
     width: "100%",
-    height: "auto",
-    display: "flex",
-    backgroundColor: "#FFFFFF",
-    padding: "30px 20px 30px 20px",
-    borderBottom: "1px solid #D4D9E2",
   },
-  lastItem: {
+  upcomingInterviewsContainer: {
+    marginTop: theme.spacing(5),
     width: "100%",
-    height: "auto",
-    display: "flex",
-    backgroundColor: "#FFFFFF",
-    padding: "30px 20px 30px 20px",
-    borderBottomLeftRadius: 6,
-    borderBottomRightRadius: 6,
   },
-  itemContent: {
-    width: "33%",
-  },
-  headerTitle: {
-    width: "33%",
-    color: "#FFFFFF",
-    fontSize: 16,
-    fontWeight: 600,
-    lineHeight: 22,
-  },
-  button: {
+  startButton: {
     padding: "10px 40px",
     borderRadius: "5em",
     fontWeight: "600",
     fontSize: 13,
     textTransform: "uppercase",
-    color: "#5E6676",
     marginRight: 10,
+    color: "#516BF6",
+    "&:hover": {
+      backgroundColor: "#516BF6",
+      color: "#FFFFFF",
+    },
   },
 }));
 
 const Dashboard = () => {
   const classes = useStyles();
-  const elements = [
-    { date: "Monday, May 25, 2020", link: "Simple Array Sum" },
-    { date: "Monday, May 25, 2020", link: "Simple Array Sum" },
-    { date: "Monday, May 25, 2020", link: "Simple Array Sum" },
-  ];
+  const [openCreateInterview, setOpenCreateInterview] = useState(false);
+  const [interviewList, setInterviewList] = useState({
+    upcoming: [],
+    passed: [],
+  });
+
+  const handleClickOpenCreateInterview = () => {
+    setOpenCreateInterview(true);
+  };
+
+  const handleCloseCreateInterview = () => {
+    setOpenCreateInterview(false);
+  };
+
+  const getInterviewList = async () => {
+    let status;
+    InterviewApi.getListInterviews()
+      .then((res) => {
+        status = res.status;
+        if (status < 500) return res.json();
+        else throw Error("Server error");
+      })
+      .then((res) => {
+        if (status === 200) {
+          setInterviewList(res);
+        } else {
+        }
+      })
+      .catch((err) => {
+        console.log(err.message);
+      });
+  };
+
+  const handleSendCreateInterview = (value) => {
+    setOpenCreateInterview(false);
+    let status;
+    InterviewApi.createInterview(value)
+      .then((res) => {
+        status = res.status;
+        if (status < 500) return res.json();
+        else throw Error("Server error");
+      })
+      .then((res) => {
+        if (status === 201) {
+          getInterviewList();
+        } else {
+        }
+      })
+      .catch((err) => {
+        console.log(err.message);
+      });
+  };
+
+  useEffect(() => {
+    getInterviewList();
+  }, []);
+
   return (
-    <div className={classes.root}>
-      <main className={classes.content}>
-        <div className={classes.appBarSpacer} />
-        <Container maxWidth="lg" className={classes.container}>
-          <Grid
-            container
-            direction="column"
-            justify="center"
-            alignItems="center"
+    <main className={classes.content}>
+      <div className={classes.appBarSpacer} />
+      <Container maxWidth="lg" className={classes.container}>
+        <Grid container direction="column" justify="center" alignItems="center">
+          <Button
+            variant="outlined"
+            color="primary"
+            className={classes.startButton}
+            onClick={handleClickOpenCreateInterview}
           >
+            Start
+          </Button>
+          <CreateInterview
+            open={openCreateInterview}
+            onClose={handleCloseCreateInterview}
+            onSend={handleSendCreateInterview}
+          ></CreateInterview>
+          <div className={classes.upcomingInterviewsContainer}>
             <Typography
               component="h4"
               variant="h4"
@@ -93,57 +129,25 @@ const Dashboard = () => {
             >
               Upcoming practice interviews
             </Typography>
-            <div className={classes.headerCard}>
-              <div className={classes.headerTitle}>
-                <Typography component="h6" variant="h6" color="inherit">
-                  When
-                </Typography>
-              </div>
-              <div className={classes.headerTitle}>
-                <Typography component="h6" variant="h6" color="inherit">
-                  Interview theme
-                </Typography>
-              </div>
-              <div className={classes.headerTitle}>
-                <Typography component="h6" variant="h6" color="inherit">
-                  Action
-                </Typography>
-              </div>
-            </div>
-            {elements.map((value, index) => {
-              return (
-                <div
-                  className={
-                    index == elements.length - 1
-                      ? classes.lastItem
-                      : classes.item
-                  }
-                >
-                  <div className={classes.itemContent}>
-                    <Typography component="h6" variant="h6" color="inherit">
-                      {value.date}
-                    </Typography>
-                  </div>
-                  <div className={classes.itemContent}>
-                    <Typography component="h6" variant="h6" color="inherit">
-                      <Link href="#">{value.link}</Link>
-                    </Typography>
-                  </div>
-                  <div className={classes.itemContent}>
-                    <Button variant="outlined" className={classes.button}>
-                      Cancel
-                    </Button>
-                    <Button variant="outlined" className={classes.button}>
-                      Join
-                    </Button>
-                  </div>
-                </div>
-              );
-            })}
-          </Grid>
-        </Container>
-      </main>
-    </div>
+            <UpcomingInterviews
+              upcomingInterviewsList={interviewList.upcoming}
+            ></UpcomingInterviews>
+          </div>
+          <div className={classes.pastInterviewsContainer}>
+            <Typography
+              component="h4"
+              variant="h4"
+              className={classes.titleCard}
+            >
+              Past practice interviews
+            </Typography>
+            <PastInterviews
+              pastInterviewsList={interviewList.passed}
+            ></PastInterviews>
+          </div>
+        </Grid>
+      </Container>
+    </main>
   );
 };
 

--- a/client/src/pages/Register.js
+++ b/client/src/pages/Register.js
@@ -28,13 +28,13 @@ const useStyles = makeStyles((theme) => ({
   },
   wrapper: {
     margin: theme.spacing(1),
-    position: "relative",
+    position: "absolute",
   },
   buttonProgress: {
     color: "#516BF6",
     position: "absolute",
     top: "50%",
-    left: "20%",
+    left: "50%",
     marginTop: -12,
     marginLeft: -12,
   },
@@ -69,7 +69,7 @@ const Register = () => {
     });
   };
 
-  const onSubmit = (data) => {
+  const onSubmit = () => {
     setLoading(true);
     let status;
     AuthApi.register(fields)

--- a/client/src/pages/login.js
+++ b/client/src/pages/login.js
@@ -35,13 +35,13 @@ const useStyles = makeStyles((theme) => ({
   },
   wrapper: {
     margin: theme.spacing(1),
-    position: "relative",
+    position: "absolute",
   },
   buttonProgress: {
     color: "#516BF6",
     position: "absolute",
     top: "50%",
-    left: "20%",
+    left: "50%",
     marginTop: -12,
     marginLeft: -12,
   },

--- a/client/src/routes/RouteContainer.js
+++ b/client/src/routes/RouteContainer.js
@@ -11,7 +11,7 @@ const RouteContainer = ({
   layoutProps,
   ...routeProps
 }) => {
-  const { userData, setUserData } = useContext(UserContext);
+  const { userData } = useContext(UserContext);
   const isSignedIn = userData.isSignedIn;
   // Check if user is authenticated and if route is private
   if (isPrivateRoute && !isSignedIn) {

--- a/client/src/utils/api/auth.js
+++ b/client/src/utils/api/auth.js
@@ -1,5 +1,3 @@
-const API_URL = process.env.REACT_APP_API_URL;
-
 export default class AuthApi {
   static login(fields) {
     return fetch("/auth/login", {

--- a/client/src/utils/api/interview.js
+++ b/client/src/utils/api/interview.js
@@ -1,0 +1,32 @@
+export default class InterviewApi {
+  static getListInterviews() {
+    return fetch("/interviews", {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      credentials: "include",
+    });
+  }
+
+  static getListDifficultyLevels() {
+    return fetch("/interviews/difficulty-levels", {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      credentials: "include",
+    });
+  }
+
+  static createInterview(fields) {
+    return fetch("/interviews", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      credentials: "include",
+      body: JSON.stringify(fields),
+    });
+  }
+}


### PR DESCRIPTION
- ADD main dashboard page with layout and header 
- GET connected user name in header with react context and provider
- ADD create Interview dialog
- FIX route auth restriction 
- GET past interview and upcoming interview
- GET difficulty levels list in create interview dialog
- Refresh interviews list after creation

![image](https://user-images.githubusercontent.com/66958060/91987847-78d53400-ed26-11ea-8545-2dbf6badc65a.png)

![image](https://user-images.githubusercontent.com/66958060/91987905-8b4f6d80-ed26-11ea-84d8-28ab290839ee.png)

